### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Determine whether UIViewController is presented as modal.
 
 [![Build Status](https://api.travis-ci.org/NZN/UIViewController-Modal.png)](https://api.travis-ci.org/NZN/UIViewController-Modal.png)
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/v/UIViewController-Modal/badge.png)](http://beta.cocoapods.org/?q=name%3Auiviewcontroller%20name%3Amodal%2A)
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/p/UIViewController-Modal/badge.png)](http://beta.cocoapods.org/?q=name%3Auiviewcontroller%20name%3Amodal%2A)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/v/UIViewController-Modal/badge.png)](http://beta.cocoapods.org/?q=name%3Auiviewcontroller%20name%3Amodal%2A)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/p/UIViewController-Modal/badge.png)](http://beta.cocoapods.org/?q=name%3Auiviewcontroller%20name%3Amodal%2A)
 [![Analytics](https://ga-beacon.appspot.com/UA-48753665-1/NZN/UIViewController-Modal/README.md)](https://github.com/igrigorik/ga-beacon)
 
 ## Requirements
@@ -18,7 +18,7 @@ You will need LLVM 3.0 or later in order to build UIViewController-Modal.
 
 ## Adding UIViewController-Modal to your project
 
-### Cocoapods
+### CocoaPods
 
 [CocoaPods](http://cocoapods.org) is the recommended way to add UIViewController-Modal to your project.
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
